### PR TITLE
MI-21684: Filtering to attributes that are available.

### DIFF
--- a/pkg/externalfunctions/externalfunctions.go
+++ b/pkg/externalfunctions/externalfunctions.go
@@ -170,6 +170,8 @@ var ExternalFunctionsMap = map[string]interface{}{
 	"LogRequestFailed":                 LogRequestFailed,
 	"LogRequestFailedDebugWithMessage": LogRequestFailedDebugWithMessage,
 	"PerformMultipleGeneralRequestsAndExtractAttributesWithOpenAiTokenOutput": PerformMultipleGeneralRequestsAndExtractAttributesWithOpenAiTokenOutput,
+	"AddAvailableAttributesToSystemPrompt": AddAvailableAttributesToSystemPrompt,
+	"ExtractDesignRequirementsAndSearchCriteria": ExtractDesignRequirementsAndSearchCriteria,
 
 	// rhsc
 	"SetCopilotGenerateRequestJsonBody": SetCopilotGenerateRequestJsonBody,


### PR DESCRIPTION
https://grantadesign.atlassian.net/browse/MI-21684

- The user's available criteria are sent to AALI alongside the design requirements. 
- Added a new function for separating the available criteria and design requirements
- The system prompt is now a system prompt template and contains ***ATTRIBUTES*** where the available criteria should live
- Added a new function for replacing ***ATTRIBUTES** with the available criteria