### PR TITLE
MaterialBU- Add tracing

### DIFF
--- a/pkg/externalfunctions/ansysmaterials.go
+++ b/pkg/externalfunctions/ansysmaterials.go
@@ -23,15 +23,19 @@
 package externalfunctions
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/ansys/aali-sharedtypes/pkg/config"
 	"github.com/ansys/aali-sharedtypes/pkg/logging"
 	"github.com/ansys/aali-sharedtypes/pkg/sharedtypes"
+	"github.com/google/uuid"
 )
 
 type Response struct {
@@ -41,6 +45,29 @@ type Response struct {
 
 type LlmCriteria struct {
 	Criteria []sharedtypes.MaterialLlmCriterion
+}
+
+func StartTrace() (string, string) {
+	traceID := generateTraceID()
+	spanID := generateSpanID()
+
+	return traceID, spanID
+}
+
+// generateTraceID generates a 128-bit trace ID in decimal format
+func generateTraceID() string {
+	id := uuid.New()
+	traceID := new(big.Int).SetBytes(id[:])
+	return traceID.String()
+}
+
+// generateSpanID generates a 64-bit span ID in decimal format
+func generateSpanID() string {
+	id := uuid.New()
+
+	// Take first 64 bits
+	spanID := binary.BigEndian.Uint64(id[:8])
+	return strconv.FormatUint(spanID, 10)
 }
 
 // SerializeResponse formats the criteria to a response suitable for the UI clients in string format

--- a/pkg/externalfunctions/ansysmaterials.go
+++ b/pkg/externalfunctions/ansysmaterials.go
@@ -47,6 +47,17 @@ type LlmCriteria struct {
 	Criteria []sharedtypes.MaterialLlmCriterion
 }
 
+// StartTrace generates a new trace ID and span ID for tracing
+//
+// Tags:
+//   - @displayName: Start new trace
+//
+// Parameters:
+//   - none
+//
+// Returns:
+//   - traceID: a 128-bit trace ID in decimal format
+//   - spanID: a 64-bit span ID in decimal format
 func StartTrace() (string, string) {
 	traceID := generateTraceID()
 	spanID := generateSpanID()
@@ -68,6 +79,30 @@ func generateSpanID() string {
 	// Take first 64 bits
 	spanID := binary.BigEndian.Uint64(id[:8])
 	return strconv.FormatUint(spanID, 10)
+}
+
+// CreateChildSpan creates a new child span context within an existing trace
+//
+// Tags:
+//   - @displayName: Create child span context
+//
+// Parameters:
+//   - traceID: the parent trace ID in decimal format
+//   - parentSpanID: the parent span ID in decimal format
+//
+// Returns:
+//   - ctx: context with trace and child span information embedded
+func CreateChildSpan(traceID string, parentSpanID string) (ctx *logging.ContextMap) {
+	// Generate a new span ID for the child
+	childSpanID := generateSpanID()
+
+	// Create a new context with trace and span information
+	ctx = &logging.ContextMap{}
+	ctx.Set(logging.TraceIdKey, traceID)
+	ctx.Set(logging.SpanIdKey, childSpanID)
+	ctx.Set(logging.ParentSpanIdKey, parentSpanID)
+
+	return ctx
 }
 
 // SerializeResponse formats the criteria to a response suitable for the UI clients in string format

--- a/pkg/externalfunctions/externalfunctions.go
+++ b/pkg/externalfunctions/externalfunctions.go
@@ -167,6 +167,7 @@ var ExternalFunctionsMap = map[string]interface{}{
 	"GetSystemPrompt": GetSystemPrompt,
 
 	// materials
+	"StartTrace":                       StartTrace,
 	"SerializeResponse":                SerializeResponse,
 	"AddGuidsToAttributes":             AddGuidsToAttributes,
 	"FilterOutNonExistingAttributes":   FilterOutNonExistingAttributes,


### PR DESCRIPTION
Manually instrumented MatBU functions for log correlation.

Each function creates its own context, and within it sets the appropriate trace id and parent span id. Context propagation is achieved by each function by returning its own span id and assigning it as global var. 

For example: <img width="1172" height="632" alt="image" src="https://github.com/user-attachments/assets/d162a81b-df53-4122-9c4c-f0c47d14451c" />

This was done to avoid having to modify some of the common functions (e.g. switch block), as I had no idea how to propagate id (or context) across them.

I am propagating id and not the whole context, as there is no info within the context itself that is worth to propagate (when creating a new context the stuff we are interested in is automatically set).

The "bad" thing about this approach is the fact that Iit creates lots of global vars (one for each function), and that its important to assign them in order. Again, I'm not sure how to use the return of a block in another block (if not by assigning it as a global var), even for blocks that we fully own, e.g. can I use the return (SpanID1) from the "Filter out Attribute" block, in the next block, without having to assign it to a global var?

<img width="957" height="332" alt="image" src="https://github.com/user-attachments/assets/cb4f6710-3104-4a80-8139-4f8d737d614e" />

Although I think the workflow will never contain that many blocks (I guess we might have 20 at most), so hopefully it's ok to have that many global var.

Regarding the tags, I found this https://docs.datadoghq.com/tracing/guide/span_and_trace_id_format/#128-bit-trace-ids, which suggests traces should be 128bit (traceid) and 64bit (span id). I have a separate change set where I added the tags (this would be in types.go)
<img width="641" height="415" alt="image" src="https://github.com/user-attachments/assets/b1e31482-739b-4d46-8091-6c41bdbcc7ba" />

Any comment is welcome!
