### PR TITLE
MatBU: Reset token monthly;

### DIFF
--- a/pkg/externalfunctions/types.go
+++ b/pkg/externalfunctions/types.go
@@ -326,10 +326,18 @@ type kvdbErrorResponse struct {
 }
 
 type materialsCustomerObject struct {
-	ApiKey          string `json:"api_key"`
-	CustomerName    string `json:"customer_name"`
-	AccessDenied    bool   `json:"access_denied"`
-	TotalTokenCount int    `json:"total_token_usage"`
-	TokenLimit      int    `json:"token_limit"`
-	WarningSent     bool   `json:"warning_sent"`
+	ApiKey          string                           `json:"api_key"`
+	CustomerName    string                           `json:"customer_name"`
+	AccessDenied    bool                             `json:"access_denied"`
+	TotalTokenCount int                              `json:"total_token_usage"`
+	TokenLimit      int                              `json:"token_limit"`
+	WarningSent     bool                             `json:"warning_sent"`
+	LastUpdated     int64                            `json:"last_updated"`
+	UsageHistory    []materialsCustomerHistoryObject `json:"usage_history"`
+}
+
+type materialsCustomerHistoryObject struct {
+	TotalTokenCount int   `json:"total_token_usage"`
+	TokenLimit      int   `json:"token_limit"`
+	Timestamp       int64 `json:"timestamp"`
 }


### PR DESCRIPTION
https://grantadesign.atlassian.net/browse/MI-21910

Reset token usage each month for each apikey. This is done by adding a timestamp (last updated time - unix time) to each customerObject. 
Each time the api key is checked, if the timestamp is from a month/year different than current one, the token reset is triggered: 

- Current token usage is saved in history(i.e. for the past timestamp)
- Current token usage  is then set to zero. 
- The timestamp is updated.

The check for the api-key happens at the beginning of the workflow (in verify api key)
<img width="930" height="245" alt="image" src="https://github.com/user-attachments/assets/35445419-6c8f-4715-be72-772d02f22e2f" />

The custormerObject that is stored in KVBD for 1 user looks like this (e.g.):
key = 12345
value =
```json
{​
  "value": {​
    "api_key": "string",​
    "customer_name": "string", ​
    "access_denied": "boolean",​
    "total_token_usage": "number",​
    "token_limit": "number",​
    "warning_sent": "boolean",​
    "last_updated": "number (Unix timestamp)",​
    "usage_history": [​
      {​
        "total_token_usage": "number",​
        "token_limit": "number",
        "timestamp": "number (Unix timestamp)​"
      }​
    ]​
  }​
}
```

There is a potential race condition happening once at the beginning of each month. Given two requests, requests A and B:
- both read the same customerObject from KVDB at the same time. 
- If the conditions are appropriate (i.e. is the beginning of the month), then both would trigger a token refresh. 
- Token refresh causes the same customerObject to be reset and being sent back to kvdb by both request A and B. However the last one arriving (for example assume request B) overwrites the other. This on itself is not an issue. 
- However, if in the time in-between request A and B (remembering that A finishes before B), request A uses any token, this usage would not be recorded. 

Given this could happens only once a month, I don't believe it's an issue. (Note that there is a similar (but worse) race condition also when doing the token update. That is worse as it could trigger any time the workflow is executed simultaneously by the same api key.)